### PR TITLE
Updated to work with Client ID requirements

### DIFF
--- a/scripts/twitch_auto_update_info.gml
+++ b/scripts/twitch_auto_update_info.gml
@@ -23,7 +23,11 @@ if (global.Update_autochck)
             if (channel_id != undefined)
                 {
                 // request new info
-                var req = http_get("https://api.twitch.tv/kraken/streams/"+string(channel_id)+"/");
+                var headers = ds_map_create(); //List of headers to be sent with the request. Mostly needed for Client ID, but useful for version number and potentialy oauth tokens.
+                ds_map_add(headers, "Client-ID", global.Client_ID); //Twitch requires a Client ID
+                ds_map_add(headers, "Accept", "application/vnd.twitchtv.v3+json"); //We want v3, it has more stuff
+
+                var req = http_request("https://api.twitch.tv/kraken/streams/"+string(channel_id)+"/", "GET", headers, "");
                 ds_map_add(global.Update_list,req,channel_id);
                 }
             }

--- a/scripts/twitch_init.gml
+++ b/scripts/twitch_init.gml
@@ -1,10 +1,11 @@
-/// twitch_init();
+/// twitch_init(client ID);
 
 // change these values depending on your program
 global.Update_autochck = false; // auto update stream info
 global.Update_interval = room_speed * 15; // auto update interval
 global.Twitch_debuglog = true; // debug logging
 global.Twitch_debugnum = "";
+global.Client_ID = argument0; 
 
 // initialize Twitch API data
 global.Stream_list = ds_map_create();

--- a/scripts/twitch_stream_get_info.gml
+++ b/scripts/twitch_stream_get_info.gml
@@ -19,5 +19,9 @@ if (ds_map_find_value(global.Stream_list,argument0) == undefined)
     ds_map_add(map,"thumb",-1);
     }
 
-var req = http_get("https://api.twitch.tv/kraken/streams/"+string(argument0)+"/");
+var headers = ds_map_create(); //List of headers to be sent with the request. Mostly needed for Client ID, but useful for version number and potentialy oauth tokens.
+ds_map_add(headers, "Client-ID", global.Client_ID); //Twitch requires a Client ID
+ds_map_add(headers, "Accept", "application/vnd.twitchtv.v3+json"); //We want v3, it has more stuff
+
+var req = http_request("https://api.twitch.tv/kraken/streams/"+string(argument0)+"/", "GET", headers, "");
 ds_map_add(global.Update_list,req,argument0);

--- a/scripts/twitch_update_info.gml
+++ b/scripts/twitch_update_info.gml
@@ -15,8 +15,12 @@ for(var i=0; i<ds_map_size(global.Stream_list); i++;)
         }
     
     if (channel_id != undefined)
-        {
-        var req = http_get("https://api.twitch.tv/kraken/streams/"+string(channel_id)+"/");
+        {        
+        var headers = ds_map_create();                                  
+        ds_map_add(headers, "Client-ID", global.Client_ID);
+        ds_map_add(headers, "Accept", "application/vnd.twitchtv.v3+json"); 
+
+        var req = http_request("https://api.twitch.tv/kraken/streams/"+string(channel_id)+"/", "GET", headers, "");
         ds_map_add(global.Update_list,req,channel_id);
         }
     }


### PR DESCRIPTION
Twitch now requires client ID's to be sent with requests, it is no longer optional. These changes allow for that. Client ID is passed into twitch_init and stored, as each application should have its own client ID. You can create an ID [here](https://www.twitch.tv/kraken/oauth2/clients/new), set the redirect to localhost as recommended, and copying the id in the URL bar. 