### PR TITLE
bugfix

### DIFF
--- a/scripts/twitch_chat_disconnect.gml
+++ b/scripts/twitch_chat_disconnect.gml
@@ -3,15 +3,15 @@
 // remove the socket
 if (global.IRC_socket > -1)
     {
-    global.IRC_socket = -1;
     network_destroy(global.IRC_socket);
+    global.IRC_socket = -1;
     }
 
 // remove old chats if they exist
 if (ds_exists(global.Chat_list,ds_type_list))
     {
-    global.Chat_list = -1;
     ds_list_destroy(global.Chat_list);
+    global.Chat_list = -1;
     }
 
 if (global.Twitch_debuglog)


### PR DESCRIPTION
`network_destroy(global.IRC_socket);` gives an error if `global.IRC_socket` is set to -1 before it gets destroyed.

 -1 is no valid socket/ds_list 